### PR TITLE
Configure verbose logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * `veneur.sink.span_ingest_total_duration_ns` gives the total time per `sink` spent ingesting spans
   * `veneur.worker.span_chan.total_elements` over `veneur.worker.span_chan.total_capacity` gives the utilization of the sink ingestion channel.
 * Introduce a generic gRPC streaming backend for trace spans. Thanks, [sdboyer](https://github.com/sdboyer)!
+* Configurable "verbose" log level using `verbose_log_level`.  [arielshaqed](https://github.com/arielshaqed)
 
 # 3.0.0, 2018-02-27
 

--- a/config.go
+++ b/config.go
@@ -71,4 +71,5 @@ type Config struct {
 	TraceLightstepNumClients      int       `yaml:"trace_lightstep_num_clients"`
 	TraceLightstepReconnectPeriod string    `yaml:"trace_lightstep_reconnect_period"`
 	TraceMaxLengthBytes           int       `yaml:"trace_max_length_bytes"`
+	VerboseLogLevel               string    `yaml:"verbose_log_level"`
 }

--- a/example.yaml
+++ b/example.yaml
@@ -172,6 +172,10 @@ sentry_dsn: ""
 # Enables Go profiling
 enable_profiling: false
 
+# Sets level for logs that appear periodically as part of normal
+# execution (currently "Completed..." logs).  Can be any logrus log
+# level (default INFO, can set to DEBUG).
+verbose_log_level: ""
 
 
 # == SINKS ==

--- a/flusher.go
+++ b/flusher.go
@@ -362,11 +362,11 @@ func (s *Server) flushForward(ctx context.Context, wms []WorkerMetrics) {
 	// about the success case
 	endpoint := fmt.Sprintf("%s/import", s.ForwardAddr)
 	if vhttp.PostHelper(span.Attach(ctx), s.HTTPClient, s.TraceClient, http.MethodPost, endpoint, jsonMetrics, "forward", true, log) == nil {
-		log.WithFields(logrus.Fields{
+		verbose(log.WithFields(logrus.Fields{
 			"metrics":     len(jsonMetrics),
 			"endpoint":    endpoint,
 			"forwardAddr": s.ForwardAddr,
-		}).Info("Completed forward to upstream Veneur")
+		}), "Completed forward to upstream Veneur")
 	}
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -384,10 +384,10 @@ func (p *Proxy) ProxyTraces(ctx context.Context, traces []DatadogTraceSpan) {
 			// support "Content-Encoding: deflate"
 			err := vhttp.PostHelper(span.Attach(ctx), p.HTTPClient, p.TraceClient, http.MethodPost, fmt.Sprintf("%s/spans", dest), batch, "flush_traces", false, log)
 			if err == nil {
-				log.WithFields(logrus.Fields{
+				verbose(log.WithFields(logrus.Fields{
 					"traces":      len(batch),
 					"destination": dest,
-				}).Info("Completed flushing traces to Datadog")
+				}), "Completed flushing traces to Datadog")
 			} else {
 				log.WithFields(
 					logrus.Fields{
@@ -456,7 +456,7 @@ func (p *Proxy) doPost(ctx context.Context, wg *sync.WaitGroup, destination stri
 	endpoint := fmt.Sprintf("%s/import", destination)
 	err := vhttp.PostHelper(ctx, p.HTTPClient, p.TraceClient, http.MethodPost, endpoint, batch, "forward", true, log)
 	if err == nil {
-		log.WithField("metrics", batchSize).Info("Completed forward to upstream Veneur")
+		verbose(log.WithField("metrics", batchSize), "Completed forward to upstream Veneur")
 	} else {
 		samples.Add(ssf.Count("forward.error_total", 1, map[string]string{"cause": "post"}))
 		log.WithError(err).WithFields(logrus.Fields{


### PR DESCRIPTION
#### Summary

Configurably log verbose "Completed" messages at other levels.

Add a new configuration option verbose_log_level (default "INFO") and log at that level.   Default `INFO` means existing configurations are unchanged.

Only handles core logging, but not plugins and sinks.

#### Motivation

When configuring `veneur` to log every second, `Completed...` logs form a significant percentage of all generated logs.  Therefore it is desirable to remove them during normal operation (but still be able to see them during debugging).

#### Test plan

Tested by hacking `server_test` to include
```
    VerboseLogLevel:     "DEBUG",
```
and seeing the `Completed ...` logs vanish from its output, then
hacking to level `ERROR` and seeing those logs at that level.  Not
added to automatic testing -- these logs were not tested before either.

#### Rollout/monitoring/revert plan

Push and deploy.  If you do add a  `verbose_log_level` configuration and revert, make sure to remove the line.